### PR TITLE
fix(openrouter): strip markdown code fences before json.loads

### DIFF
--- a/graphiti_bridge/openrouter_client.py
+++ b/graphiti_bridge/openrouter_client.py
@@ -224,13 +224,23 @@ class OpenRouterClient(LLMClient):
                     pass
 
             result = response.choices[0].message.content or ''
-            
+
             # Check if response is HTML (Cloudflare/infrastructure error)
             if result.strip().startswith(('<!DOCTYPE html>', '<html')):
                 error_msg = _parse_html_error(result)
                 logger.error(error_msg)
                 raise InfrastructureError(error_msg)
-            
+
+            # Strip markdown code fences if present. Claude (and some other
+            # models) wrap JSON output in ```json ... ``` when the downstream
+            # provider doesn't enforce response_format=json_schema natively
+            # (e.g. Anthropic via OpenAI-compat shims, some local gateways).
+            stripped = result.strip()
+            if stripped.startswith('```'):
+                stripped = re.sub(r'^```(?:json|JSON)?\s*\n?', '', stripped)
+                stripped = re.sub(r'\n?\s*```\s*$', '', stripped)
+                result = stripped.strip()
+
             return json.loads(result)
 
         except openai.RateLimitError as e:


### PR DESCRIPTION
## Summary

`OpenRouterClient._generate_response` passes `response.choices[0].message.content` directly to `json.loads()`. When a downstream provider doesn't enforce `response_format=json_schema` natively (e.g. Anthropic Claude via OpenAI-compat shims, some local models behind LiteLLM-style gateways), the model wraps its JSON output in a markdown code fence:

~~~
```json
{ ... }
```
~~~

`json.loads()` then fails with

```
Expecting value: line 1 column 1 (char 0)
```

because the first character is a backtick. The retry logic in `generate_response` just appends an "invalid response" instruction and tries again, which produces the same fenced output and exhausts `MAX_RETRIES`.

This PR strips a leading ` ```json ` / ` ``` ` fence and the trailing ` ``` ` before parsing. When the content is already bare JSON, the logic is a no-op, so providers that honor `json_schema` strictly (native OpenRouter → GPT-5, OpenAI direct) are unaffected.

## Observed behavior

Routing MegaMem through an in-house OpenAI-compat gateway (OmniRoute, OpenRouter-shaped) that load-balances across Claude Haiku, Groq Llama-3.3-70B, and others: Claude Haiku consistently returns fenced JSON; Groq returns bare JSON. With the current code every Haiku response dies at `json.loads`, masking an otherwise-valid extraction and preventing sync.

## Tests

Minimal unit test (none exist in the repo for this client currently; a standalone example):

```python
import re

def strip_fences(s):
    stripped = s.strip()
    if stripped.startswith('\`\`\`'):
        stripped = re.sub(r'^\`\`\`(?:json|JSON)?\s*\n?', '', stripped)
        stripped = re.sub(r'\n?\s*\`\`\`\s*$', '', stripped)
        return stripped.strip()
    return s

assert strip_fences('\`\`\`json\n{\"a\":1}\n\`\`\`')  == '{\"a\":1}'
assert strip_fences('\`\`\`\n{\"a\":1}\n\`\`\`')       == '{\"a\":1}'
assert strip_fences('{\"a\":1}')                        == '{\"a\":1}'
assert strip_fences('  {\"a\":1}  ')                    == '  {\"a\":1}  '  # bare JSON w/ whitespace unchanged
```

## Risks / edge cases considered

- **Responses containing fences *inside* the JSON body** — the regex anchors to start/end of the string, so inner fences are left alone.
- **Commentary before or after the fence** (e.g. "Here is your JSON: ```...```") — this PR does not handle that case. If it becomes a problem, a fallback would be a permissive `{...}` or `[...]` balanced-brace extraction. Keeping this PR minimal.
- **Models that already honor `json_schema` strictly** — they produce bare JSON, so the `startswith('\`\`\`')` guard short-circuits and the code path is a no-op. No regression risk.

No new imports; `re` is already in use in the file.

## Notes for reviewers

The retry logic in `generate_response` appends an "invalid response" instruction when parsing fails. That text is not removed by this PR, but in practice retries should no longer happen for the fenced-JSON cause, so it's moot. Can be revisited separately if desired.

## Related

Companion PR (make OpenRouter base URL configurable) is independent; either can land first.