### PR TITLE
feat(openrouter): allow overriding base URL via env var / config

### DIFF
--- a/graphiti_bridge/sync.py
+++ b/graphiti_bridge/sync.py
@@ -902,8 +902,15 @@ async def initialize_graphiti(config: BridgeConfig, debug: bool = False):
                     if debug:
                         logger.info(f"Appended preset to small model: {processed_small_model}")
             
-            # OpenRouter uses an OpenAI-compatible API surface; use OpenAIGenericClient with OpenRouter base URL
-            openrouter_base = "https://openrouter.ai/api/v1"
+            # OpenRouter uses an OpenAI-compatible API surface; use OpenAIGenericClient with OpenRouter base URL.
+            # Resolution order: explicit config field -> environment variable -> public OpenRouter default.
+            # This allows routing through OpenAI-compatible gateways (LiteLLM, self-hosted proxies) while
+            # defaulting to public OpenRouter for users who haven't configured an override.
+            openrouter_base = (
+                getattr(config, 'openrouter_base_url', None)
+                or os.environ.get("OPENROUTER_BASE_URL")
+                or "https://openrouter.ai/api/v1"
+            )
             llm_config = LLMConfig(
                 api_key=llm_api_key,
                 model=processed_model,


### PR DESCRIPTION
## Summary

`sync.py` hardcodes the OpenRouter base URL as `https://openrouter.ai/api/v1` when instantiating the LLM client. This PR makes the base URL configurable — resolved in priority order from (1) an explicit config field `openrouter_base_url`, (2) the environment variable `OPENROUTER_BASE_URL`, (3) the existing public OpenRouter default.

This enables users to route MegaMem through OpenAI-compatible gateways or self-hosted proxies (LiteLLM, OmniRoute, ollama-openai-compat, private deployments) while still defaulting to public OpenRouter out of the box.

**No behavior change for existing users** — the default is unchanged, and both new resolution paths only activate when the user explicitly sets them.

## Motivation

Routing MegaMem via a local load-balancing gateway lets us:

- Fan-out sync across multiple providers (Haiku, Groq, MiniMax, LongCat) behind a single endpoint
- Apply tier-based routing that spreads cost across flat-rate subscriptions
- Use a gateway that already holds provider keys centrally

Currently the only way to do this is patching `sync.py` locally, which gets overwritten on every plugin update.

## Optional TS-side follow-up (plugin settings field)

Python alone accepts `openrouter_base_url` from `config` if the attribute exists. To expose it in the UI, the TS plugin code would need:

1. **Settings interface** — add `openrouterBaseUrl?: string` to the plugin's settings type definition.
2. **Settings tab UI** — add a text input under the OpenRouter section. Placeholder: `https://openrouter.ai/api/v1`. Help text: "Override the OpenRouter API base URL. Useful for routing through an OpenAI-compatible gateway (LiteLLM, self-hosted proxy). Leave blank to use public OpenRouter."
3. **Config serialization** — when spawning the Python bridge, include `openrouter_base_url` in the config JSON.

I haven't drafted the TS patch because I don't have the TS source handy — happy to follow up once the Python side is merged and you confirm the approach. The Python-only change is fully usable today via `OPENROUTER_BASE_URL` env var, so a phased merge is fine.

## Testing

Set the env var and verify MegaMem sync routes through the alternate endpoint:

```bash
export OPENROUTER_BASE_URL="http://localhost:4000/v1"  # e.g. LiteLLM
# launch Obsidian from this shell so the env propagates
```

Then confirm logs contain `base_url=http://localhost:4000/v1` instead of `openrouter.ai`.

## Risks / edge cases considered

- **API key mismatch** — if a user points `OPENROUTER_BASE_URL` at a gateway but leaves `apiKeys.openrouter` as their public OpenRouter key, auth will fail. No code change needed; the error message is already clear. Could be noted in documentation.
- **Env var inheritance on Windows** — `setx` doesn't affect already-running shells, so users may need to restart Obsidian from a fresh shell. This is an OS quirk, not something this PR addresses. The config-field path (TS follow-up) avoids this problem entirely.
- **Default behavior unchanged** — when neither config nor env is set, the code falls through to the existing public URL. No regression for users who aren't aware of the feature.

No new imports; `os` is already in use in `sync.py`.

## Related

Companion PR (strip markdown fences on JSON responses) is independent; either can land first.