### PR TITLE
fix(graphiti): invert source_description precedence so config override wins (closes #11)

### DIFF
--- a/graphiti_bridge/sync.py
+++ b/graphiti_bridge/sync.py
@@ -1525,15 +1525,19 @@ async def create_generic_text_episode(graphiti, note_name: str, clean_text: str,
         else:
             formatted_reference_time = reference_time
 
-        # Use source description from frontmatter.type if present; fall back to note_name for untyped notes
+        # Use source description: config override wins (cross-writer federation use case),
+        # frontmatter.type as fallback, note_name as final default (Issue #11).
         frontmatter_type = None
         if metadata and isinstance(metadata, dict):
             frontmatter_type = metadata.get('type')
-        if frontmatter_type:
+        config_override = getattr(config, 'source_description', None) if config else None
+        if config_override:
+            source_description = config_override
+        elif frontmatter_type:
             source_description = str(frontmatter_type)
         else:
-            # Phase 1: use note filename as source_description when no type (custom ontology disabled)
-            source_description = (getattr(config, 'source_description', None) if config else None) or note_name or 'obsidian_mm_default'
+            # Phase 1: use note filename as source_description (custom ontology disabled)
+            source_description = note_name or 'obsidian_mm_default'
 
         # Merge frontmatter into the body if metadata is provided; otherwise use body as-is
         merged_body = clean_text
@@ -1644,14 +1648,18 @@ async def create_custom_entity_episode(graphiti, note_name: str, clean_text: str
         if not entity_types:
             return await create_generic_text_episode(graphiti, note_name, clean_text, reference_time, group_id, logger, database_type, config, custom_extraction_instructions=custom_extraction_instructions, saga_name=saga_name, saga_previous_uuid=saga_previous_uuid, episode_meta=episode_meta)
 
-        # Use source description from frontmatter type if available; fall back to note_name for untyped notes
+        # Use source description: config override wins (cross-writer federation use case),
+        # frontmatter type as fallback, note_name as final default (Issue #11).
         frontmatter_type = None
         if metadata and isinstance(metadata, dict):
             frontmatter_type = metadata.get('type')
-        if frontmatter_type:
+        config_override = getattr(config, 'source_description', None) if config else None
+        if config_override:
+            source_description = config_override
+        elif frontmatter_type:
             source_description = str(frontmatter_type)
         else:
-            source_description = (getattr(config, 'source_description', None) if config else None) or note_name or 'obsidian_mm_default'
+            source_description = note_name or 'obsidian_mm_default'
 
         # Merge frontmatter into the body
         merged_body = clean_text


### PR DESCRIPTION
## Summary

Implements maintainer-endorsed Option (a) from #11: invert `source_description` precedence so `config.source_description` wins when explicitly set, with `frontmatter.type` as the fallback.

Per @C-Bjorn's comment on #11 (2026-04-24): _"We'd go with option (a) — invert the precedence so config.source_description wins when explicitly set, with frontmatter.type as the fallback. It's the smallest change, fully backward-compatible..."_

## Patch shape (matches maintainer's endorsed exact shape)

Both call sites — `sync.py:create_generic_text_episode` (~line 1528) and `sync.py:create_custom_entity_episode` (~line 1648) — get the same change:

```python
config_override = getattr(config, 'source_description', None) if config else None
if config_override:
    source_description = config_override
elif frontmatter_type:
    source_description = str(frontmatter_type)
else:
    source_description = note_name or 'obsidian_mm_default'
```

15 insertions / 7 deletions. Net +8 lines (4 per call site).

## Backwards compatibility

Fully backward-compatible:
- Users who don't set `config.source_description` → `config_override` is `None` → `frontmatter_type` wins exactly as before
- Users who set `config.source_description` → config wins (the documented federation use case from #11)

No existing `:Episodic` nodes are mutated. No write-path behavior changes for default users.

## Test plan

- [ ] (existing test harness) verify default-user behavior unchanged: with `config.source_description` unset, `frontmatter.type` still produces `source_description = type-value`
- [ ] verify federation behavior: with `config.source_description = "Archive capture - {project} - {filename}"` (or any string), `source_description = config_value` regardless of `frontmatter.type` presence
- [ ] verify both call sites: `create_generic_text_episode` AND `create_custom_entity_episode` paths

## Sibling PR context

This is a sibling to #14 (`feat(graphiti): emit source_file property on :Episodic nodes`). Both target cross-writer federation:
- #14 — closes the missing-property gap (plugin doesn't emit `source_file`)
- This PR — closes the unreachable-config gap (`config.source_description` never fires for typed notes)

Together they make the plugin's `:Episodic` writes federation-ready. PRs are independent — landing either is useful, landing both is complete.

## Closes

Closes #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)